### PR TITLE
Chain Adapter

### DIFF
--- a/libraries/machine.cpp
+++ b/libraries/machine.cpp
@@ -181,6 +181,11 @@ namespace machine
     }
   }
 
+  void machine::push_string(std::string s)
+  {
+    stack.push_front(s);
+  }
+
   // TODO: Make better
   // TODO: Return string instead?
   void machine::print_stack()
@@ -221,6 +226,7 @@ namespace machine
     big_word va, vb, vc, vd, ve, vf, vg, vh, vi, vj, vk, vl, vm, vn, vo, vp, vq;
     stack_variant sv;
     signed_big_word sa, sb, sc;
+    std::string* ss;
     switch (op)
     {
       case stop_opcode:
@@ -439,8 +445,21 @@ namespace machine
         push_word( msg.destination );
         break;
       case balance_opcode:
+        std::cout << 1 << std::endl;
         logger << "op balance" << std::endl;
-        // TODO
+        {
+          sv = stack.front(); // wallet_name
+          stack.pop_front();
+          if (ss = boost::get<std::string>(&sv))
+          {
+            push_word( adapter.get_balance(*ss) );
+          }
+          else
+          {
+            state = machine_state::error;
+            error_message.emplace("Balance operation type error");
+          }
+        }
         break;
       case origin_opcode:
         logger << "op origin" << std::endl;
@@ -2456,6 +2475,11 @@ namespace machine
   machine_state machine::get_state()
   {
     return state;
+  }
+
+  boost::optional<std::string> machine::get_error_message()
+  {
+    return error_message;
   }
 
   std::stringstream& machine::get_logger()

--- a/libraries/machine.hpp
+++ b/libraries/machine.hpp
@@ -16,7 +16,7 @@ namespace machine
 typedef uint8_t word;
 typedef boost::multiprecision::uint256_t big_word;
 typedef boost::multiprecision::int256_t signed_big_word;
-typedef boost::variant<big_word> stack_variant;
+typedef boost::variant<big_word, std::string> stack_variant;
 
 enum opcode
 {
@@ -236,6 +236,11 @@ struct context
    }
  */
 
+struct chain_adapter
+{
+  std::function< uint64_t(std::string) > get_balance;
+};
+
 class machine
 {
   size_t pc = 0;
@@ -248,23 +253,26 @@ class machine
   std::vector<word> return_value;
   boost::optional<std::string> error_message;
   std::stringstream logger;
+  chain_adapter adapter;
 
   void push_word(stack_variant v);
   big_word pop_word();
   void log(std::string output);
 
   public:
-  machine(context ctx, std::vector<word> code, message msg)
-    : ctx(ctx), code(code), msg(msg)
+  machine(context ctx, std::vector<word> code, message msg, chain_adapter adapter)
+    : ctx(ctx), code(code), msg(msg), adapter(adapter)
   {
   }
 
   big_word peek_word();
+  void push_string(std::string s);
   void print_stack();
   size_t stack_length();
   void step();
   bool is_running();
   machine_state get_state();
+  boost::optional<std::string> get_error_message();
   std::stringstream& get_logger();
   std::string to_json();
 

--- a/programs/xgtvm.cpp
+++ b/programs/xgtvm.cpp
@@ -52,6 +52,20 @@ static struct option long_options[] = {
   {0, 0, 0, 0}
 };
 
+machine::chain_adapter make_chain_adapter()
+{
+  std::function< uint64_t(std::string) > get_balance = [](std::string wallet_name) -> uint64_t
+  {
+    return 0;
+  };
+
+  machine::chain_adapter adapter = {
+    get_balance
+  };
+
+  return adapter;
+}
+
 int main(int argc, char** argv)
 {
   int c;
@@ -88,7 +102,8 @@ int main(int argc, char** argv)
     machine::context ctx = {true, 0x5c477758};
     machine::message msg = {};
     std::vector<machine::word> code = process_eval(input);
-    machine::machine m(ctx, code, msg);
+    machine::chain_adapter adapter = make_chain_adapter();
+    machine::machine m(ctx, code, msg, adapter);
     std::string line;
     while (m.is_running())
     {

--- a/programs/xgtvm_tests.cpp
+++ b/programs/xgtvm_tests.cpp
@@ -9,6 +9,20 @@
     std::cerr << "  " << ( result ? "\e[32m" : "\e[31m" ) << ( message ) << "\e[0m" << std::endl; \
   }
 
+machine::chain_adapter make_chain_adapter()
+{
+  std::function< uint64_t(std::string) > get_balance = [](std::string wallet_name) -> uint64_t
+  {
+    return 0;
+  };
+
+  machine::chain_adapter adapter = {
+    get_balance
+  };
+
+  return adapter;
+}
+
 int main(int argc, char** argv)
 {
   test_that("machine runs and halts")
@@ -16,7 +30,8 @@ int main(int argc, char** argv)
     std::vector<machine::word> input = {0x00};
     machine::context ctx = {true, 0x00};
     machine::message msg = {};
-    machine::machine m(ctx, input, msg);
+    machine::chain_adapter adapter = make_chain_adapter();
+    machine::machine m(ctx, input, msg, adapter);
     assert_message( "machine should start running", m.get_state() == machine::machine_state::running );
     while (m.is_running())
       m.step();
@@ -29,7 +44,8 @@ int main(int argc, char** argv)
     std::vector<machine::word> input = {};
     machine::context ctx = {true, 0x00};
     machine::message msg = {};
-    machine::machine m(ctx, input, msg);
+    machine::chain_adapter adapter = make_chain_adapter();
+    machine::machine m(ctx, input, msg, adapter);
     while (m.is_running())
       m.step();
     assert_message( "machine should stop when done executing", m.get_state() == machine::machine_state::stopped );
@@ -41,7 +57,8 @@ int main(int argc, char** argv)
     std::vector<machine::word> input = {0x42, 0x00};
     machine::context ctx = {true, 0x5c477758};
     machine::message msg = {};
-    machine::machine m(ctx, input, msg);
+    machine::chain_adapter adapter = make_chain_adapter();
+    machine::machine m(ctx, input, msg, adapter);
     while (m.is_running())
       m.step();
     assert_message( "machine should stop when done executing", m.get_state() == machine::machine_state::stopped );
@@ -54,12 +71,32 @@ int main(int argc, char** argv)
     std::vector<machine::word> input = {0x60, 0x02, 0x60, 0x03, 0x01, 0x00};
     machine::context ctx = {true, 0x00};
     machine::message msg = {};
-    machine::machine m(ctx, input, msg);
+    machine::chain_adapter adapter = make_chain_adapter();
+    machine::machine m(ctx, input, msg, adapter);
     while (m.is_running())
       m.step();
     assert_message( "machine should stop when done executing", m.get_state() == machine::machine_state::stopped );
     assert_message( "stack has correct length", m.stack_length() == 1 );
     assert_message( "top of stack has correct value", m.peek_word() == 5 );
+  }
+
+  test_that("machine can get a wallet's balance via the chain adapter")
+  {
+    std::vector<machine::word> input = {0x31, 0x00};
+    machine::context ctx = {true, 0x00};
+    machine::message msg = {};
+    machine::chain_adapter adapter = make_chain_adapter();
+    adapter.get_balance = [](std::string wallet_name) -> uint64_t
+    {
+      return 2;
+    };
+    machine::machine m(ctx, input, msg, adapter);
+    m.push_string("alice");
+    while (m.is_running())
+      m.step();
+    assert_message( "machine should stop when done executing", m.get_state() == machine::machine_state::stopped );
+    assert_message( "stack has correct length", m.stack_length() == 1 );
+    assert_message( "top of stack has correct value", m.peek_word() == 2 );
   }
 
   return 0;


### PR DESCRIPTION
- [x] Allow strings as stack variants (for wallet names)
- [x] Basic chain adapter, whose methods can be replaced from `xgt`-side, to allow limited access to chain resources
- [x] Implement the `BALANCE` operation (opcode `0x31`) using the chain adapter